### PR TITLE
ci(release): automated semantic release with release-plz

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
     # (which bumps the version) has been merged.
     needs: release-pr
     runs-on: ubuntu-latest
+    concurrency:
+      group: release
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

- Replace manual tag-based release workflow with `release-plz`
- Automatic version bump based on conventional commits (feat→minor, fix→patch)
- Auto-generated CHANGELOG.md
- Publishes to crates.io + creates GitHub Release when Release PR is merged

## Technical Details

Uses `MarcoIeni/release-plz-action@v0.5` which:
1. On push to main → creates/updates a Release PR with Cargo.toml version bump + CHANGELOG
2. When Release PR merges → publishes to crates.io, creates git tag, creates GitHub Release

Requires `CRATES_IO_TOKEN` secret (already configured).

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched release automation to a PR-first workflow that requires a release PR before publishing.
  * Introduced a staged two-step release flow: a release-PR preparation step followed by a publish step that creates releases and publishes packages.
  * Hardened CI by scoping job permissions and adding concurrency controls; release notes generation is now handled by the automated release flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->